### PR TITLE
Refactor atom namespace

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -1,14 +1,19 @@
 import {
-  type Atom,
   cdata,
   type Channel,
   generateRSS,
   type Item,
-} from "./mod.ts";
+  type Namespaces,
+} from "../src/mod.ts";
 
 const channel: Channel = {
   title: "Example Web",
   link: "https://example.com",
+  atom_link: {
+    href: "https://example.com/rss.xml",
+    rel: "self",
+    type: "application/atom+xml",
+  },
   description: cdata("Example description"),
   ttl: 60,
   language: "en",
@@ -39,16 +44,10 @@ const items: Item[] = [
   },
 ];
 
-const atom: Atom = {
-  link: {
-    href: "https://example.com/feed",
-    rel: "self",
-    type: "application/rss+xml",
-  },
-};
+const namespaces: Namespaces = ["atom"];
 
 if (import.meta.main) {
-  const xml = generateRSS({ channel, items, atom });
+  const xml = generateRSS({ channel, items, namespaces });
   const data = new TextEncoder().encode(xml);
   await Deno.writeFile("rss.xml", data);
 }

--- a/src/generate_rss.ts
+++ b/src/generate_rss.ts
@@ -1,6 +1,6 @@
 import { stringify } from "./stringify.ts";
 import { createXMLTree } from "./ast.ts";
-import type { Atom, Channel, Item } from "./generate_rss_types.ts";
+import type { Channel, Item, Namespaces } from "./generate_rss_types.ts";
 import { buildXMLObj } from "./xmlobj.ts";
 
 /**
@@ -9,11 +9,11 @@ import { buildXMLObj } from "./xmlobj.ts";
  * @returns RSS feed as string
  */
 const generateRSS = (
-  data: { channel: Channel; items?: Item[]; atom?: Atom },
+  data: { channel: Channel; items?: Item[]; namespaces?: Namespaces },
 ): string => {
-  const { channel, items, atom } = data;
+  const { channel, items, namespaces } = data;
 
-  const xmlObj = buildXMLObj({ channel, items, atom });
+  const xmlObj = buildXMLObj({ channel, items, namespaces });
 
   const xmlTree = createXMLTree(xmlObj);
 

--- a/src/generate_rss_types.ts
+++ b/src/generate_rss_types.ts
@@ -36,6 +36,8 @@ export type Channel = {
   skipDays?: SkipDays[];
 
   skipHours?: number;
+
+  atom_link?: AtomLink;
 };
 
 export type Cloud = {
@@ -133,12 +135,12 @@ export type Source = {
   url: string;
 };
 
-export type Atom = {
-  link: {
-    href: string;
+export type AtomLink = {
+  href: string;
 
-    rel: string;
+  rel: "alternate" | "enclosure" | "self" | "related" | "self" | "via";
 
-    type: string;
-  };
+  type: string;
 };
+
+export type Namespaces = ["atom"];

--- a/src/generate_rss_types.ts
+++ b/src/generate_rss_types.ts
@@ -138,7 +138,7 @@ export type Source = {
 export type AtomLink = {
   href: string;
 
-  rel: "alternate" | "enclosure" | "self" | "related" | "self" | "via";
+  rel: "alternate" | "enclosure" | "related" | "self" | "via";
 
   type: string;
 };

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,13 +1,13 @@
 export { generateRSS } from "./generate_rss.ts";
 export { cdata } from "./cdata.ts";
 export type {
-  Atom,
   Channel,
   Cloud,
   Enclosure,
   Guid,
   Image,
   Item,
+  Namespaces,
   SkipDays,
   Source,
   TextInput,


### PR DESCRIPTION
This pull request refactors the RSS generation code to replace the `Atom` type with a more modular approach using `AtomLink` and `Namespaces`. It also introduces support for specifying XML namespaces dynamically, improving flexibility when generating RSS feed.