### PR TITLE
Feature dc namespace

### DIFF
--- a/examples/main.ts
+++ b/examples/main.ts
@@ -30,6 +30,9 @@ const items: Item[] = [
     content: {
       encoded: cdata("<p>Example content</p>"),
     },
+    dc: {
+      creator: "John Doe",
+    },
     link: "https://example.com/articles/1",
     guid: {
       isPermaLink: true,
@@ -43,6 +46,9 @@ const items: Item[] = [
     content: {
       encoded: cdata("<p>Example content</p>"),
     },
+    dc: {
+      creator: "John Doe",
+    },
     link: "https://example.com/articles/2",
     guid: {
       isPermaLink: true,
@@ -52,7 +58,7 @@ const items: Item[] = [
   },
 ];
 
-const namespaces: Namespaces = ["atom", "content"];
+const namespaces: Namespaces = ["atom", "content", "dc"];
 
 if (import.meta.main) {
   const xml = generateRSS({ channel, items, namespaces });

--- a/src/generate_rss_types.ts
+++ b/src/generate_rss_types.ts
@@ -93,6 +93,7 @@ export type SkipDays =
   | "Saturday"
   | "Sunday";
 
+// Following http://www.w3.org/2005/Atom.
 export type Atom = {
   link: {
     href: string;
@@ -125,6 +126,8 @@ export type Item = {
   source?: Source;
 
   content?: Content;
+
+  dc?: DC;
 };
 
 export type Enclosure = {
@@ -147,8 +150,15 @@ export type Source = {
   url: string;
 };
 
+// Following http://purl.org/rss/1.0/modules/content/.
 export type Content = {
   encoded: string;
 };
 
-export type Namespaces = ("atom" | "content")[];
+// Following http://purl.org/dc/elements/1.1/.
+export type DC = {
+  creator: string;
+  // TODO: Add other properties.
+};
+
+export type Namespaces = ("atom" | "content" | "dc")[];

--- a/src/xmlobj.ts
+++ b/src/xmlobj.ts
@@ -47,6 +47,9 @@ const buildNamespaces = (namespaces: Namespaces): { [key: string]: string } => {
       case "content":
         ret["@xmlns:content"] = "http://purl.org/rss/1.0/modules/content/";
         break;
+      case "dc":
+        ret["@xmlns:dc"] = "http://purl.org/dc/elements/1.1/";
+        break;
       default:
         continue;
     }
@@ -162,9 +165,11 @@ const toChannelItem = (data: Item[]): ChannelItem[] => {
   return data.map((item) => ({
     ...optionalProp<string>("title", item.title),
     ...optionalProp<string>("description", item.description),
+    ...optionalProp<string>("content:encoded", item.content?.encoded),
     ...optionalProp<string>("link", item.link),
     ...optionalProp<string>("author", item.author),
     ...optionalProp<string[]>("category", item.category),
+    ...optionalProp<string>("dc:creator", item.dc?.creator),
     ...optionalProp<string>("comments", item.comments),
     ...optionalProp<Enclosure, ItemEnclosure>(
       "enclosure",
@@ -178,7 +183,6 @@ const toChannelItem = (data: Item[]): ChannelItem[] => {
       item.source,
       toItemSource,
     ),
-    ...optionalProp<string>("content:encoded", item.content?.encoded),
   }));
 };
 


### PR DESCRIPTION
This pull request introduces support for the Dublin Core (DC) metadata module in the RSS generation system. The most important changes include adding a new `dc` property to the `Item` type, updating the namespaces to include `dc`, and modifying the XML generation logic to handle the new metadata. Additionally, comments were added to clarify the standards being followed for various types.