### PR TITLE
Implement slash namespace

### DIFF
--- a/src/generate_rss_types.ts
+++ b/src/generate_rss_types.ts
@@ -128,6 +128,8 @@ export type Item = {
   content?: Content;
 
   dc?: DC;
+
+  slash?: Slash;
 };
 
 export type Enclosure = {
@@ -161,4 +163,9 @@ export type DC = {
   // TODO: Add other properties.
 };
 
-export type Namespaces = ("atom" | "content" | "dc")[];
+// Following http://purl.org/rss/1.0/modules/slash/.
+export type Slash = {
+  comments: number;
+};
+
+export type Namespaces = ("atom" | "content" | "dc" | "slash")[];

--- a/src/xmlobj.ts
+++ b/src/xmlobj.ts
@@ -50,6 +50,9 @@ const buildNamespaces = (namespaces: Namespaces): { [key: string]: string } => {
       case "dc":
         ret["@xmlns:dc"] = "http://purl.org/dc/elements/1.1/";
         break;
+      case "slash":
+        ret["@xmlns:slash"] = "http://purl.org/rss/1.0/modules/slash/";
+        break;
       default:
         continue;
     }
@@ -171,6 +174,7 @@ const toChannelItem = (data: Item[]): ChannelItem[] => {
     ...optionalProp<string[]>("category", item.category),
     ...optionalProp<string>("dc:creator", item.dc?.creator),
     ...optionalProp<string>("comments", item.comments),
+    ...optionalProp<string>("slash:comments", item.slash?.comments.toString()),
     ...optionalProp<Enclosure, ItemEnclosure>(
       "enclosure",
       item.enclosure,


### PR DESCRIPTION
This pull request introduces support for the RSS `slash` namespace, enabling the handling of `slash:comments` in RSS feeds. The changes include updates to type definitions, namespace handling, and serialization logic.