### PR TITLE
fix: Channel may contail Item[]

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,6 @@ import {
   type Item,
 } from "jsr:@taga3s/rss-generator";
 
-const channel: Channel = {
-  title: "Example Web",
-  link: "https://example.com",
-  description: cdata("Example description"),
-  ttl: 60,
-  language: "en",
-  category: ["sports", "politics", "technology"],
-  copyright: "Example Web",
-};
-
 const items: Item[] = [
   {
     title: "Example Title 1",
@@ -65,8 +55,19 @@ const items: Item[] = [
   },
 ];
 
+const channel: Channel = {
+  title: "Example Web",
+  link: "https://example.com",
+  description: cdata("Example description"),
+  ttl: 60,
+  language: "en",
+  category: ["sports", "politics", "technology"],
+  copyright: "Example Web",
+  items: items,
+};
+
 if (import.meta.main) {
-  const xml = generateRSS({ channel, items });
+  const xml = generateRSS({ channel });
   const data = new TextEncoder().encode(xml);
   await Deno.writeFile("rss.xml", data);
 }

--- a/src/generate-rss.test.ts
+++ b/src/generate-rss.test.ts
@@ -6,21 +6,6 @@ import { assertSnapshot } from "@std/testing/snapshot";
 const fixture = (): {
   xml: string;
 } => {
-  const channel: Channel = {
-    title: "Example Web",
-    link: "https://example.com",
-    atom: {
-      link: {
-        href: "https://example.com/rss.xml",
-      },
-    },
-    description: cdata("Example description"),
-    ttl: 60,
-    language: "en",
-    category: ["sports", "politics", "technology"],
-    copyright: "Example Web",
-  };
-
   const items: Item[] = [
     {
       title: "Example Title 1",
@@ -50,8 +35,24 @@ const fixture = (): {
     },
   ];
 
+  const channel: Channel = {
+    title: "Example Web",
+    link: "https://example.com",
+    atom: {
+      link: {
+        href: "https://example.com/rss.xml",
+      },
+    },
+    description: cdata("Example description"),
+    ttl: 60,
+    language: "en",
+    category: ["sports", "politics", "technology"],
+    copyright: "Example Web",
+    items: items,
+  };
+
   return {
-    xml: generateRSS({ channel, items }),
+    xml: generateRSS({ channel }),
   };
 };
 

--- a/src/generate-rss.ts
+++ b/src/generate-rss.ts
@@ -1,6 +1,6 @@
 import { stringify } from "./stringify.ts";
 import { createXMLTree } from "./ast.ts";
-import type { Channel, Item } from "./generate-rss_types.ts";
+import type { Channel } from "./generate-rss_types.ts";
 import { buildXMLObj } from "./xmlobj.ts";
 
 /**
@@ -9,11 +9,11 @@ import { buildXMLObj } from "./xmlobj.ts";
  * @returns RSS feed as string
  */
 export const generateRSS = (
-  data: { channel: Channel; items?: Item[] },
+  data: { channel: Channel },
 ): string => {
-  const { channel, items } = data;
+  const { channel } = data;
 
-  const xmlObj = buildXMLObj({ channel, items });
+  const xmlObj = buildXMLObj({ channel });
 
   const xmlTree = createXMLTree(xmlObj);
 

--- a/src/generate-rss_types.ts
+++ b/src/generate-rss_types.ts
@@ -41,6 +41,8 @@ export interface Channel {
   skipDays?: SkipDays[];
 
   skipHours?: number;
+
+  items?: Item[];
 }
 
 export interface Cloud {

--- a/src/xmlobj.ts
+++ b/src/xmlobj.ts
@@ -60,9 +60,8 @@ const DEFAULT_ATOM_LINK_REL_TYPE = "application/rss+xml";
 
 export const buildXMLObj = (input: {
   channel: Channel;
-  items?: Item[];
 }): XMLObj => {
-  const { channel, items } = input;
+  const { channel } = input;
 
   const optionalProps = genOptionalProps<ChannelBase>();
 
@@ -133,7 +132,7 @@ export const buildXMLObj = (input: {
         ),
         ...optionalProps<Item[], ChannelItem[]>(
           "item",
-          items,
+          channel.items,
           toChannelItems,
         ),
       },


### PR DESCRIPTION
https://www.rssboard.org/rss-specification#hrelementsOfLtitemgt

Moving items into Channel makes semantic sense since RSS items are children of the channel element in the RSS specification.